### PR TITLE
Added missing i++ increment for getValue while loop.

### DIFF
--- a/src/HomeAssistantMQTT.cpp
+++ b/src/HomeAssistantMQTT.cpp
@@ -231,6 +231,7 @@ String HomeAssistantMQTT::getValue(String item)
       if (strcmp(values[i]->item, item.c_str()) == 0)
         return String(values[i]->value);
     }
+	i++;
   }
   return String("");
 }

--- a/src/HomeAssistantMQTT.h
+++ b/src/HomeAssistantMQTT.h
@@ -43,7 +43,7 @@ class HomeAssistantMQTT
   
     HomeAssistantMQTT();
     void begin(WiFiClient* wifiClient, const char* server, const uint16_t port);
-    void loop();
+    bool loop();
 
     bool connected();
     void readValues();


### PR DESCRIPTION
A quick bugfix in `HomeAssistantMQTT::getValue` to add a missing increment for `i` needed when looping over `values` entries.